### PR TITLE
ngp-piwik can use scope variable to populate attribute

### DIFF
--- a/dist/angular-piwik.js
+++ b/dist/angular-piwik.js
@@ -94,11 +94,13 @@
         replace: false,
         transclude: true,
         compile: function(tElement, tAttrs, transclude) {
-          var script_elem;
-          script_elem = $document[0].createElement('script');
-          script_elem.setAttribute('src', tAttrs.ngpSetJsUrl);
-          $document[0].body.appendChild(script_elem);
           return {
+            pre: function(scope, elem, attrs) {
+              var script_elem;
+              script_elem = $document[0].createElement('script');
+              script_elem.setAttribute('src', attrs.ngpSetJsUrl);
+              return $document[0].body.appendChild(script_elem);
+            },
             post: function(scope, elem, attrs) {
               var k, v;
               for (k in attrs) {

--- a/lib/angular-piwik.coffee
+++ b/lib/angular-piwik.coffee
@@ -122,17 +122,18 @@ mod.directive 'ngpPiwik', [
       else
         call.push param for param in attr_val.split(',')
       return call
-      
+
     dir_def_obj =
       restrict: 'E'
       replace: no
       transclude: yes
       compile: (tElement, tAttrs, transclude) ->
-        script_elem = $document[0].createElement 'script'
-        script_elem.setAttribute 'src', tAttrs.ngpSetJsUrl
-        $document[0].body.appendChild script_elem
-
         return {
+          pre: (scope, elem, attrs) ->
+            script_elem = $document[0].createElement 'script'
+            script_elem.setAttribute 'src', attrs.ngpSetJsUrl
+            $document[0].body.appendChild script_elem
+
           post: (scope, elem, attrs) ->
             for own k,v of attrs when /^ngp/.test(k)
               do (k,v) ->


### PR DESCRIPTION
This change enables the use of scope variable in the ngp-piwik attr. Which gives the flexibility of passing values rather then hardcoding it.
