### PR TITLE
Duplicate calls

### DIFF
--- a/dist/angular-piwik.js
+++ b/dist/angular-piwik.js
@@ -73,7 +73,7 @@
       var arr_param_methods, build_p_call, comma_regex, dir_def_obj;
       $window['_paq'] = $window['_paq'] || [];
       arr_param_methods = ['setDomains', 'setDownloadClasses', 'setIgnoreClasses', 'setLinkClasses'];
-      comma_regex = /,/g;
+      comma_regex = /,/;
       comma_regex.compile(comma_regex);
       build_p_call = function(method, attr_val) {
         var call, param, _i, _len, _ref;

--- a/dist/angular-piwik.js
+++ b/dist/angular-piwik.js
@@ -70,7 +70,7 @@
 
   mod.directive('ngpPiwik', [
     '$window', '$document', 'Piwik', 'PiwikActionMethods', function($window, $document, Piwik, PiwikActionMethods) {
-      var arr_param_methods, build_p_call, comma_regex, dir_def_obj;
+      var arr_param_methods, build_p_call, comma_regex, dir_def_obj, push_paq;
       $window['_paq'] = $window['_paq'] || [];
       arr_param_methods = ['setDomains', 'setDownloadClasses', 'setIgnoreClasses', 'setLinkClasses'];
       comma_regex = /,/;
@@ -88,6 +88,32 @@
           }
         }
         return call;
+      };
+      push_paq = function(method, attr_val) {
+        var existingPaq, index, item, pcall, value, _i, _len, _results;
+        pcall = build_p_call(method, attr_val);
+        existingPaq = (function() {
+          var _i, _len, _ref, _results;
+          _ref = $window['_paq'];
+          _results = [];
+          for (_i = 0, _len = _ref.length; _i < _len; _i++) {
+            item = _ref[_i];
+            if (item[0] === method) {
+              _results.push(item);
+            }
+          }
+          return _results;
+        })();
+        if (existingPaq.length > 0) {
+          _results = [];
+          for (index = _i = 0, _len = pcall.length; _i < _len; index = ++_i) {
+            value = pcall[index];
+            _results.push(existingPaq[0][index] = value);
+          }
+          return _results;
+        } else {
+          return $window['_paq'].push(pcall);
+        }
       };
       dir_def_obj = {
         restrict: 'E',
@@ -111,9 +137,9 @@
                     if (!(__indexOf.call(PiwikActionMethods, method) >= 0)) {
                       return;
                     }
-                    $window['_paq'].push(build_p_call(method, v));
+                    push_paq(method, v);
                     return attrs.$observe(k, function(val) {
-                      return $window['_paq'].push(build_p_call(method, val));
+                      return push_paq(method, val);
                     });
                   })(k, v);
                 }

--- a/lib/angular-piwik.coffee
+++ b/lib/angular-piwik.coffee
@@ -143,7 +143,16 @@ mod.directive 'ngpPiwik', [
       else
         call.push param for param in attr_val.split(',')
       return call
-      
+
+    push_paq = (method, attr_val) ->
+      pcall = build_p_call(method, attr_val)
+      existingPaq = (item for item in $window['_paq'] when item[0] is method)
+      if(existingPaq.length > 0)
+        for value, index in pcall
+          existingPaq[0][index] = value
+      else
+        $window['_paq'].push pcall
+
     dir_def_obj =
       restrict: 'E'
       replace: no
@@ -159,19 +168,13 @@ mod.directive 'ngpPiwik', [
               do (k,v) ->
                 method = k[3].toLowerCase() + k[4..]
                 return if not (method in PiwikActionMethods)
-                $window['_paq'].push build_p_call(method, v)
+                push_paq(method, v)
+
                 attrs.$observe k, (val) ->
-                  $window['_paq'].push build_p_call(method, val)
+                  push_paq(method, val)
 
             $window['_paq'].push ['trackPageView']
         }
 
     return dir_def_obj
 ]
-
-
-
-
-
-
-

--- a/lib/angular-piwik.coffee
+++ b/lib/angular-piwik.coffee
@@ -133,9 +133,9 @@ mod.directive 'ngpPiwik', [
       'setIgnoreClasses'
       'setLinkClasses'
     ]
-    comma_regex = /,/g
+    comma_regex = /,/
     comma_regex.compile comma_regex
-    
+
     build_p_call = (method, attr_val) ->
       call = [method]
       if ((method in arr_param_methods) and comma_regex.test(attr_val))

--- a/test/directivesSpec.coffee
+++ b/test/directivesSpec.coffee
@@ -38,7 +38,7 @@ describe 'Piwik Directives', ->
 
   it 'should create call queue', ->
     expect(win['_paq']).toBeDefined()
-    expect(win['_paq'].length).toEqual(7)
+    expect(win['_paq'].length).toEqual(4)
 
   it 'should place trackerUrl on call queue before trackPageView', ->
     cmd = shift_until win['_paq'], 'setTrackerUrl'


### PR DESCRIPTION
This is my implementation of https://github.com/mike-spainhower/angular-piwik/pull/3

The original implementation ignored subsequent requests.  This implementation updates the existing calls in the _paq queue if they exist.

Firstly, apologies for my coffeescript, I'm not very familiar with the language so I'm happy to accept any suggestions for improvements.

Also, there may be a better way of doing this, perhaps having a hash that gets pushed to the queue at a later point in the lifecycle.  However I don't know the piwik library well enough to take a different approach.  If you have a better one let me know and I'll refactor.

Thanks
Peter